### PR TITLE
Switch to more stable curse API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,30 +58,23 @@ minecraft {
 
 repositories {
     maven {
-        url = "http://dvs1.progwml6.com/files/maven"
+        url = "https://www.cursemaven.com"
     }
     maven {
         url = "https://maven.blamejared.com/"
     }
-    maven {
-        url = "http://chickenbones.net/maven/"
-    }
-    maven {
-        url = "https://minecraft.curseforge.com/api/maven"
-    }
 }
 
 dependencies {
-    deobfCompile "mezz.jei:jei_1.12.2:4.16.1.301:api"
-    runtime      "mezz.jei:jei_1.12.2:4.16.1.301"
-    runtime      "curse.maven:resource-loader:2477566"
+    deobfCompile "curse.maven:jei-238222:3040523"
+    runtime      "curse.maven:resource-loader-226447:2477566"
     deobfCompile "CraftTweaker2:CraftTweaker2-MC1120-Main:1.12-4.1.20.660"
-    deobfCompile "curse.maven:cucumber:2645867"
-    deobfCompile "curse.maven:hwyla:2568751"
-    deobfCompile "curse.maven:packagedauto:3418955"
-    deobfCompile "curse.maven:pexc:3214400"
-    deobfCompile "gregtechce:gregtech:1.12.2:1.17.0.764"
-    deobfCompile "codechicken-lib-1-8:CodeChickenLib-1.12.2:3.2.3.358:universal"
+    deobfCompile "curse.maven:cucumber-272335:2645867"
+    deobfCompile "curse.maven:hwyla-253449:2568751"
+    deobfCompile "curse.maven:packagedauto-308380:3614585"
+    deobfCompile "curse.maven:packagedexcrafting-322861:3214400"
+    deobfCompile "curse.maven:gregtechce-293327:3478805"
+    deobfCompile "curse.maven:codechicken-lib-1-8-242818:2779848"
 }
 
 processResources {


### PR DESCRIPTION
Uses the `https://www.cursemaven.com` maven endpoint for fetching dependencies, which is more stable in my experience than what we were using before (which failed on my first attempt to get this project up and running again)