### PR TITLE
Always register custom singularity oredict recipes

### DIFF
--- a/src/main/java/com/blakebr0/extendedcrafting/item/ItemSingularityCustom.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/item/ItemSingularityCustom.java
@@ -20,7 +20,6 @@ import net.minecraftforge.common.config.ConfigCategory;
 import net.minecraftforge.common.config.Configuration;
 import net.minecraftforge.common.crafting.CraftingHelper;
 import net.minecraftforge.fml.common.registry.ForgeRegistries;
-import net.minecraftforge.oredict.OreDictionary;
 import org.apache.commons.lang3.text.WordUtils;
 
 import java.util.ArrayList;
@@ -161,11 +160,7 @@ public class ItemSingularityCustom extends ItemMeta implements IModelHelper, IEn
 				} else if (parts.length == 2) {
 					if (((String) value).startsWith("ore:")) {
 						String ore = ((String) value).substring(4);
-						if (OreDictionary.doesOreNameExist(ore)) {
-							if (!OreDictionary.getOres(ore).isEmpty()) {
-								CompressorRecipeManager.getInstance().addRecipe(new ItemStack(this, 1, meta), CraftingHelper.getIngredient(ore), ModConfig.confSingularityAmount, Ingredient.fromStacks(ItemSingularity.getCatalystStack()), false, ModConfig.confSingularityRF);
-							}
-						}
+						CompressorRecipeManager.getInstance().addRecipe(new ItemStack(this, 1, meta), CraftingHelper.getIngredient(ore), ModConfig.confSingularityAmount, Ingredient.fromStacks(ItemSingularity.getCatalystStack()), false, ModConfig.confSingularityRF);
 					} else {
 						item = ForgeRegistries.ITEMS.getValue(new ResourceLocation(parts[0], parts[1]));
 						if (item != null) {


### PR DESCRIPTION
resolve #31
because https://github.com/Nomifactory/ExtendedCrafting/commit/fba62b60de217ad659c390c2b0ce23185ddf5c0c moved registering custom singularity recipes into preInit, any oredict created afterwards (eg crafttweaker) wouldnt register a singularity due to over-cautious validation checks. however, if a singularity is registered to an oredict that doesnt exist/has no items: nothing bad happens. in fact, this happens by default in `ItemSingularity.java`, since it tries to register a singularity to `ingotArdite`, and the dev environment doesnt have any `ingotArdite`.
as such, this PR changes `ItemSingularityCustom.java` to always register oredict singularities, even when the oredict doesnt exist or has no items.

tested with
```cfg
    S:custom_singularities <
        101;experience;ore:itemXP;b3f43b
     >
```
and both with and without
```zenscript
<ore:itemXP>.add(<minecraft:dirt>);
```