### PR TITLE
Fix issues with Combination Crafting

### DIFF
--- a/src/main/java/com/blakebr0/extendedcrafting/client/gui/GuiCraftingCore.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/client/gui/GuiCraftingCore.java
@@ -35,10 +35,10 @@ public class GuiCraftingCore extends GuiContainer {
 	}
 
 	private int getProgressBarScaled(int pixels) {
-		int i = this.tile.getProgress();
+		long i = this.tile.getProgress();
 		CombinationRecipe recipe = this.tile.getRecipe();
 		long j = recipe == null ? 0 : recipe.getCost();
-		return (int) (j != 0 && i != 0 ? (long) i * pixels / j : 0);
+		return (int) (j != 0 && i != 0 ? i * pixels / j : 0);
 	}
 
 	@Override

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/combinationcrafting/CombinationCraftingWrapper.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/combinationcrafting/CombinationCraftingWrapper.java
@@ -28,11 +28,11 @@ public class CombinationCraftingWrapper implements IRecipeWrapper {
 	public CombinationCraftingWrapper(IJeiHelpers helpers, CombinationRecipe recipe) {
 		this.helpers = helpers;
 		this.recipe = recipe;
-		int period = recipe.getPedestalIngredients()
+		int period = Math.max(1, recipe.getPedestalIngredients()
 				.stream()
 				.map(Ingredient::getMatchingStacks)
 				.map(a -> a.length)
-				.reduce(1, (a, b) -> a * b);
+				.reduce(1, (a, b) -> a * b));
 		timer = helpers.getGuiHelper()
 				.createTickTimer(period * 20, period, false);
 	}

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/combinationcrafting/CombinationCraftingWrapper.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/combinationcrafting/CombinationCraftingWrapper.java
@@ -47,6 +47,13 @@ public class CombinationCraftingWrapper implements IRecipeWrapper {
 			ArrayList<String> tooltip = new ArrayList<>();
 			tooltip.add(Utils.localize("tooltip.ec.items_required"));
 			Object2IntLinkedOpenHashMap<String> tooltipCount = new Object2IntLinkedOpenHashMap<>();
+
+			ItemStack[] coreStacks = recipe.getInputIngredient().getMatchingStacks();
+			if(coreStacks.length != 0) {
+				String line = coreStacks[timer.getValue() % coreStacks.length].getDisplayName();
+				tooltipCount.put(line, tooltipCount.getInt(line) + 1);
+			}
+
 			for (Ingredient ing : recipe.getPedestalIngredients()) {
 				ItemStack[] stacks = ing.getMatchingStacks();
 				if(stacks.length == 0) continue;

--- a/src/main/java/com/blakebr0/extendedcrafting/tile/TileCraftingCore.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/tile/TileCraftingCore.java
@@ -199,7 +199,6 @@ public class TileCraftingCore extends TileEntity implements ITickable, IGTEnergy
 		super.readFromNBT(tag);
 		this.inventory.deserializeNBT(tag);
 		this.progress = tag.getLong("Progress");
-		if (progress == 0L && tag.hasKey("Progress", 3)) this.progress = tag.getInteger("Progress");
 		this.energy.setEnergy(tag.getInteger("Energy"));
 	}
 

--- a/src/main/java/com/blakebr0/extendedcrafting/tile/TileCraftingCore.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/tile/TileCraftingCore.java
@@ -166,6 +166,8 @@ public class TileCraftingCore extends TileEntity implements ITickable, IGTEnergy
 
 		if (!recipes.isEmpty()) {
 			for (CombinationRecipe recipe : recipes) {
+				if (recipe.getPedestalIngredients().isEmpty())
+					return recipe;
 				List<TilePedestal> pedestals = this.getPedestalsWithStuff(recipe, locations);
 				if (!pedestals.isEmpty())
 					return recipe;

--- a/src/main/java/com/blakebr0/extendedcrafting/tile/TileCraftingCore.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/tile/TileCraftingCore.java
@@ -39,7 +39,7 @@ public class TileCraftingCore extends TileEntity implements ITickable, IGTEnergy
 	private final ItemStackHandler inventory = new StackHandler();
 	private final EnergyStorageCustom energy = new EnergyStorageCustom(ModConfig.confCraftingCoreRFCapacity);
 
-	private int progress;
+	private long progress;
 	private int oldEnergy;
 	private int pedestalCount;
 
@@ -177,7 +177,7 @@ public class TileCraftingCore extends TileEntity implements ITickable, IGTEnergy
 		return null;
 	}
 
-	public int getProgress() {
+	public long getProgress() {
 		return this.progress;
 	}
 
@@ -198,7 +198,8 @@ public class TileCraftingCore extends TileEntity implements ITickable, IGTEnergy
 	public void readFromNBT(NBTTagCompound tag) {
 		super.readFromNBT(tag);
 		this.inventory.deserializeNBT(tag);
-		this.progress = tag.getInteger("Progress");
+		this.progress = tag.getLong("Progress");
+		if (progress == 0L && tag.hasKey("Progress", 3)) this.progress = tag.getInteger("Progress");
 		this.energy.setEnergy(tag.getInteger("Energy"));
 	}
 
@@ -206,7 +207,7 @@ public class TileCraftingCore extends TileEntity implements ITickable, IGTEnergy
 	public NBTTagCompound writeToNBT(NBTTagCompound tag) {
 		tag = super.writeToNBT(tag);
 		tag.merge(this.inventory.serializeNBT());
-		tag.setInteger("Progress", this.progress);
+		tag.setLong("Progress", this.progress);
 		tag.setInteger("Energy", this.energy.getEnergyStored());
 
 		return tag;


### PR DESCRIPTION
changes in this PR:
- changes the `progress` field of the `TileCraftingCore` to be a `long` instead of an `int`.
- allows recipes without any pedestal ingredients to be craftable.
- clamps JEI's tick timer to have a minimum period of 1.
- adds the center item of the Combination Crafting recipe to the ingredients tooltip


resolves #21 and resolves #16