### PR TITLE
Avoid Ultimate Singularity recipe errors when irrelevant

### DIFF
--- a/src/main/java/com/blakebr0/extendedcrafting/item/ItemSingularityUltimate.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/item/ItemSingularityUltimate.java
@@ -80,6 +80,9 @@ public class ItemSingularityUltimate extends ItemBase implements IEnableable {
 	}
 
 	public static void addSingularityToRecipe(ItemStack stack) {
+		if (!ModConfig.confUltimateSingularityRecipe || !ModConfig.confSingularityEnabled)
+			return;
+
 		Item item = stack.getItem();
 		if (item instanceof ItemSingularity) {
 			if (blacklistDefaults.contains(stack.getMetadata())) {


### PR DESCRIPTION
changes in this PR:
- prevents adding Singularities to the `singularities` field in `ItemSingularityUltimate` if the recipe for the Ultimate Singularity is disabled. this field is exclusively used for creating the recipe, and its only referenced there if the Ultimate Singularity recipe is not disabled.

without this, having more than a total of 81 Singularities will generate errors in the config, which can be easily done via creating a large number of Custom Singularities (as done in DJ2).